### PR TITLE
Fix CI failure on ubuntu-latest for python 3.7

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -75,27 +75,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # TEMPORARY: Debug git metadata
-      - if: ${{ matrix.use-container }}
-        name: Debug git metadata
-        run: |
-          git status
-          git describe --tags || echo "No tags found"
-          ls -la .git/
-      # TEMPORARY: Debug permissions
-      - if: ${{ matrix.use-container }}
-        name: Debug permissions
-        run: |
-          ls -la
-          whoami
-          id
-      # TEMPORARY: Debug directory structure
-      - if: ${{ matrix.use-container }}
-        name: Debug directory structure
-        run: |
-          pwd
-          python -c "import os; print(os.getcwd())"
-          ls -R | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//  /g' -e 's/^/  /'
       - if: ${{ !matrix.use-container }}
         name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }} (non-containers)
         uses: actions/setup-python@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,11 +51,11 @@ jobs:
             os: "ubuntu-latest"
         include:
           - python-version: "3.5"
-            os: "macos-12"
+            os: "macos-13"
           - python-version: "3.6"
-            os: "macos-12"
+            os: "macos-13"
           - python-version: "3.7"
-            os: "macos-12"
+            os: "macos-13"
           - python-version: "2.7"
             os: "ubuntu-20.04"
           - python-version: "3.5"
@@ -104,10 +104,19 @@ jobs:
         run: python -m tox -e coverage
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v3
+        if: matrix.os != 'macos-13'
         with:
           file: ./.tox/coverage.xml
           name: ${{ matrix.os }}:${{ matrix.python-version }}
           fail_ci_if_error: false
+      - name: Report coverage to Codecov
+        uses: codecov/codecov-action@v3
+        if: matrix.os == 'macos-13'
+        with:
+          file: ./.tox/coverage.xml
+          name: ${{ matrix.os }}:${{ matrix.python-version }}
+          fail_ci_if_error: false
+          version: v0.7.3 # see https://github.com/codecov/codecov-action/issues/1549
 
   other:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "2.7",
-          "3.5",
-          "3.6",
-          "3.7",
           "3.8",
           "3.9",
           "3.10",
@@ -30,53 +26,76 @@ jobs:
           "pypy-3.8",
         ]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - python-version: "2.7"
-            os: "ubuntu-latest"
-          - python-version: "2.7"
-            os: "windows-latest"
-          - python-version: "2.7"
-            os: "macos-latest"
-          - python-version: "3.5"
-            os: "macos-latest"
-          - python-version: "3.6"
-            os: "macos-latest"
-          - python-version: "3.7"
-            os: "macos-latest"
-          - python-version: "3.5"
-            os: "ubuntu-latest"
-          - python-version: "3.6"
-            os: "ubuntu-latest"
-          - python-version: "3.7"
-            os: "ubuntu-latest"
+        use-container: [false]
         include:
           - python-version: "3.5"
             os: "macos-13"
+            use-container: false
           - python-version: "3.6"
             os: "macos-13"
+            use-container: false
           - python-version: "3.7"
             os: "macos-13"
-          - python-version: "2.7"
-            os: "ubuntu-20.04"
+            use-container: false
           - python-version: "3.5"
-            os: "ubuntu-20.04"
+            os: "windows-latest"
+            use-container: false
           - python-version: "3.6"
-            os: "ubuntu-20.04"
+            os: "windows-latest"
+            use-container: false
           - python-version: "3.7"
-            os: "ubuntu-22.04"
+            os: "windows-latest"
+            use-container: false
+          - python-version: "2.7"
+            os: "ubuntu-latest"
+            use-container: true
+          - python-version: "3.4"
+            os: "ubuntu-latest"
+            use-container: true
+          - python-version: "3.5"
+            os: "ubuntu-latest"
+            use-container: true
+          - python-version: "3.6"
+            os: "ubuntu-latest"
+            use-container: true
+          - python-version: "3.7"
+            os: "ubuntu-latest"
+            use-container: true
     runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.use-container && format('python:{0}', matrix.python-version) || '' }}
     env:
       TOXENV: py
     steps:
-      - uses: actions/checkout@v3
-      - if: ${{ matrix.python-version == '2.7' }}
+      - if: ${{ matrix.use-container }}
+        name: Install git (containers)
+        run: apt-get update && apt-get install -y git
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # TEMPORARY: Debug git metadata
+      - if: ${{ matrix.use-container }}
+        name: Debug git metadata
         run: |
-          sudo apt-get install python-is-python2
-          curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
-          python get-pip.py
-        name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      - if: ${{ matrix.python-version != '2.7' }}
-        name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+          git status
+          git describe --tags || echo "No tags found"
+          ls -la .git/
+      # TEMPORARY: Debug permissions
+      - if: ${{ matrix.use-container }}
+        name: Debug permissions
+        run: |
+          ls -la
+          whoami
+          id
+      # TEMPORARY: Debug directory structure
+      - if: ${{ matrix.use-container }}
+        name: Debug directory structure
+        run: |
+          pwd
+          python -c "import os; print(os.getcwd())"
+          ls -R | grep ":$" | sed -e 's/:$//' -e 's/[^-][^\/]*\//  /g' -e 's/^/  /'
+      - if: ${{ !matrix.use-container }}
+        name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }} (non-containers)
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -98,6 +117,17 @@ jobs:
       - name: Run updatezinfo.py (Unix)
         run: ./ci_tools/retry.sh python updatezinfo.py
         if: runner.os != 'Windows'
+      # TEMPORARY: Debug SCM configuration
+      - name: Debug SCM configuration
+        run: |
+          cat setup.cfg || echo "No setup.cfg found"
+          cat pyproject.toml || echo "No pyproject.toml found"
+        # TEMPORARY: debug tox
+      - name: Debug package versions
+        run: |
+          python -m pip list | grep setuptools || echo "setuptools not installed"
+          python -m pip list | grep setuptools-scm || echo "setuptools-scm not installed"
+          python -V
       - name: Run tox
         run: python -m tox
       - name: Generate coverage.xml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [
           "3.8",
           "3.9",
@@ -25,38 +26,32 @@ jobs:
           "pypy-2.7",
           "pypy-3.8",
         ]
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        use-container: [false]
         include:
-          - python-version: "3.5"
-            os: "macos-13"
-            use-container: false
-          - python-version: "3.6"
-            os: "macos-13"
-            use-container: false
-          - python-version: "3.7"
-            os: "macos-13"
-            use-container: false
-          - python-version: "3.5"
-            os: "windows-latest"
-            use-container: false
-          - python-version: "3.6"
-            os: "windows-latest"
-            use-container: false
-          - python-version: "3.7"
-            os: "windows-latest"
-            use-container: false
-          - python-version: "2.7"
-            os: "ubuntu-latest"
+          # Older versions (3.7 and earlier) are included separately since they need
+          # special handling (ie use an older os or a container)
+          - os: "macos-13"
+            python-version: "3.5"
+          - os: "macos-13"
+            python-version: "3.6"
+          - os: "macos-13"
+            python-version: "3.7"
+          - os: "windows-latest"
+            python-version: "3.5"
+          - os: "windows-latest"
+            python-version: "3.6"
+          - os: "windows-latest"
+            python-version: "3.7"
+          - os: "ubuntu-latest"
+            python-version: "2.7"
             use-container: true
-          - python-version: "3.5"
-            os: "ubuntu-latest"
+          - os: "ubuntu-latest"
+            python-version: "3.5"
             use-container: true
-          - python-version: "3.6"
-            os: "ubuntu-latest"
+          - os: "ubuntu-latest"
+            python-version: "3.6"
             use-container: true
-          - python-version: "3.7"
-            os: "ubuntu-latest"
+          - os: "ubuntu-latest"
+            python-version: "3.7"
             use-container: true
     runs-on: ${{ matrix.os }}
     container:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,7 +71,8 @@ jobs:
         run: |
           apt-get update && apt-get install -y git
           git config --global --add safe.directory /__w/dateutil/dateutil
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - if: ${{ !matrix.use-container }}
@@ -84,38 +85,31 @@ jobs:
           PIP_TRUSTED_HOST: ${{ contains(fromJson('["3.5"]'), matrix.python-version) && env.pypi-hosts || '' }}
       - name: Install dependencies
         run: python -m pip install -U tox six
-      - name: Install zic (Windows)
+      - if: runner.os == 'Windows'
+        name: Install zic (Windows)
         run: |
           curl https://get.enterprisedb.com/postgresql/postgresql-9.5.21-2-windows-x64-binaries.zip --output $env:GITHUB_WORKSPACE\postgresql9.5.21.zip
           unzip -oq $env:GITHUB_WORKSPACE\postgresql9.5.21.zip -d .postgresql
-        if: runner.os == 'Windows'
-      - name: Run updatezinfo.py (Windows)
+      - if: runner.os == 'Windows'
+        name: Run updatezinfo.py (Windows)
         run: |
           $env:Path += ";$env:GITHUB_WORKSPACE\.postgresql\pgsql\bin"
           ci_tools/retry.bat python updatezinfo.py
-        if: runner.os == 'Windows'
-      - name: Run updatezinfo.py (Unix)
+      - if: runner.os != 'Windows'
+        name: Run updatezinfo.py (Unix)
         run: ./ci_tools/retry.sh python updatezinfo.py
-        if: runner.os != 'Windows'
       - name: Run tox
         run: python -m tox
       - name: Generate coverage.xml
         run: python -m tox -e coverage
       - name: Report coverage to Codecov
         uses: codecov/codecov-action@v3
-        if: matrix.os != 'macos-13'
         with:
           file: ./.tox/coverage.xml
           name: ${{ matrix.os }}:${{ matrix.python-version }}
           fail_ci_if_error: false
-      - name: Report coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: matrix.os == 'macos-13'
-        with:
-          file: ./.tox/coverage.xml
-          name: ${{ matrix.os }}:${{ matrix.python-version }}
-          fail_ci_if_error: false
-          version: v0.7.3 # see https://github.com/codecov/codecov-action/issues/1549
+          # See https://github.com/codecov/codecov-action/issues/1549
+          version: ${{ matrix.os == 'macos-13' && 'v0.7.3' || 'latest' }}
 
   other:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,12 +59,6 @@ jobs:
     env:
       TOXENV: py
     steps:
-      - if: ${{ matrix.use-container }}
-        name: Configure git (containers)
-        # In container builds, we need to explicitly trust the workspace directory
-        # because the container runs as root while the directory is owned by the runner user
-        run: |
-          git config --global --add safe.directory ${{ github.workspace }}
       - name: Checkout code
         uses: actions/checkout@v4
       - if: ${{ !matrix.use-container }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,6 +47,8 @@ jobs:
             os: "ubuntu-latest"
           - python-version: "3.6"
             os: "ubuntu-latest"
+          - python-version: "3.7"
+            os: "ubuntu-latest"
         include:
           - python-version: "3.5"
             os: "macos-12"
@@ -60,6 +62,8 @@ jobs:
             os: "ubuntu-20.04"
           - python-version: "3.6"
             os: "ubuntu-20.04"
+          - python-version: "3.7"
+            os: "ubuntu-22.04"
     runs-on: ${{ matrix.os }}
     env:
       TOXENV: py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,8 +68,6 @@ jobs:
           git config --global --add safe.directory /__w/dateutil/dateutil
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - if: ${{ !matrix.use-container }}
         name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }} (non-containers)
         uses: actions/setup-python@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false      # TEMPORARY for debugging
       matrix:
         python-version: [
           "3.8",
@@ -49,9 +50,6 @@ jobs:
           - python-version: "2.7"
             os: "ubuntu-latest"
             use-container: true
-          - python-version: "3.4"
-            os: "ubuntu-latest"
-            use-container: true
           - python-version: "3.5"
             os: "ubuntu-latest"
             use-container: true
@@ -69,7 +67,11 @@ jobs:
     steps:
       - if: ${{ matrix.use-container }}
         name: Install git (containers)
-        run: apt-get update && apt-get install -y git
+        # In container builds, we need to explicitly trust the workspace directory
+        # because the container runs as root while the directory is owned by the runner user
+        run: |
+          apt-get update && apt-get install -y git
+          git config --global --add safe.directory /__w/dateutil/dateutil
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -130,6 +132,12 @@ jobs:
           python -V
       - name: Run tox
         run: python -m tox
+        # TEMPORARY: debug tox
+      - name: Debug package versions (after tox)
+        run: |
+          python -m pip list | grep setuptools || echo "setuptools not installed"
+          python -m pip list | grep setuptools-scm || echo "setuptools-scm not installed"
+          python -V
       - name: Generate coverage.xml
         run: python -m tox -e coverage
       - name: Report coverage to Codecov
@@ -148,66 +156,66 @@ jobs:
           fail_ci_if_error: false
           version: v0.7.3 # see https://github.com/codecov/codecov-action/issues/1549
 
-  other:
-    runs-on: "ubuntu-latest"
-    strategy:
-      matrix:
-        toxenv: ["docs", "tz", "precommit"]
-    env:
-      TOXENV: ${{ matrix.toxenv }}
+  # other:
+  #   runs-on: "ubuntu-latest"
+  #   strategy:
+  #     matrix:
+  #       toxenv: ["docs", "tz", "precommit"]
+  #   env:
+  #     TOXENV: ${{ matrix.toxenv }}
 
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: ${{ matrix.toxenv }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install tox
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -U tox
-      - name: Run action
-        run: tox
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - name: ${{ matrix.toxenv }}
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Install tox
+  #       run: |
+  #         python -m pip install --upgrade pip
+  #         python -m pip install -U tox
+  #     - name: Run action
+  #       run: tox
 
-  darker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-      - uses: akaihola/darker@0fb2501a3f6c1b2d64976afa57885aeec0601182
-        # pinned due to unreleased fix: https://github.com/akaihola/darker/issues/489
-        with:
-          options: "--check --diff --color --isort"
-          src: "."
-          version: "~=1.7.1"
+  # darker:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: actions/setup-python@v5
+  #     - uses: akaihola/darker@0fb2501a3f6c1b2d64976afa57885aeec0601182
+  #       # pinned due to unreleased fix: https://github.com/akaihola/darker/issues/489
+  #       with:
+  #         options: "--check --diff --color --isort"
+  #         src: "."
+  #         version: "~=1.7.1"
 
-  build-dist:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Install tox
-        run: python -m pip install -U tox
-      - name: Run tox
-        run: python -m tox -e build
-      - name: Check generation
-        run: |
-          exactly_one() {
-            value=$(find dist -iname $1 | wc -l)
-            if [ $value -ne 1 ]; then
-              echo "Found $value instances of $1, not 1"
-              return 1
-            else
-              echo "Found exactly 1 instance of $value"
-            fi
-          }
-          # Check that exactly one tarball and one wheel are created
-          exactly_one '*.tar.gz'
-          exactly_one '*.whl'
+  # build-dist:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Install tox
+  #       run: python -m pip install -U tox
+  #     - name: Run tox
+  #       run: python -m tox -e build
+  #     - name: Check generation
+  #       run: |
+  #         exactly_one() {
+  #           value=$(find dist -iname $1 | wc -l)
+  #           if [ $value -ne 1 ]; then
+  #             echo "Found $value instances of $1, not 1"
+  #             return 1
+  #           else
+  #             echo "Found exactly 1 instance of $value"
+  #           fi
+  #         }
+  #         # Check that exactly one tarball and one wheel are created
+  #         exactly_one '*.tar.gz'
+  #         exactly_one '*.whl'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -119,25 +119,8 @@ jobs:
       - name: Run updatezinfo.py (Unix)
         run: ./ci_tools/retry.sh python updatezinfo.py
         if: runner.os != 'Windows'
-      # TEMPORARY: Debug SCM configuration
-      - name: Debug SCM configuration
-        run: |
-          cat setup.cfg || echo "No setup.cfg found"
-          cat pyproject.toml || echo "No pyproject.toml found"
-        # TEMPORARY: debug tox
-      - name: Debug package versions
-        run: |
-          python -m pip list | grep setuptools || echo "setuptools not installed"
-          python -m pip list | grep setuptools-scm || echo "setuptools-scm not installed"
-          python -V
       - name: Run tox
         run: python -m tox
-        # TEMPORARY: debug tox
-      - name: Debug package versions (after tox)
-        run: |
-          python -m pip list | grep setuptools || echo "setuptools not installed"
-          python -m pip list | grep setuptools-scm || echo "setuptools-scm not installed"
-          python -V
       - name: Generate coverage.xml
         run: python -m tox -e coverage
       - name: Report coverage to Codecov

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,12 +60,11 @@ jobs:
       TOXENV: py
     steps:
       - if: ${{ matrix.use-container }}
-        name: Install git (containers)
+        name: Configure git (containers)
         # In container builds, we need to explicitly trust the workspace directory
         # because the container runs as root while the directory is owned by the runner user
         run: |
-          apt-get update && apt-get install -y git
-          git config --global --add safe.directory /__w/dateutil/dateutil
+          git config --global --add safe.directory ${{ github.workspace }}
       - name: Checkout code
         uses: actions/checkout@v4
       - if: ${{ !matrix.use-container }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,6 @@ env:
 jobs:
   test:
     strategy:
-      fail-fast: false      # TEMPORARY for debugging
       matrix:
         python-version: [
           "3.8",
@@ -118,66 +117,66 @@ jobs:
           fail_ci_if_error: false
           version: v0.7.3 # see https://github.com/codecov/codecov-action/issues/1549
 
-  # other:
-  #   runs-on: "ubuntu-latest"
-  #   strategy:
-  #     matrix:
-  #       toxenv: ["docs", "tz", "precommit"]
-  #   env:
-  #     TOXENV: ${{ matrix.toxenv }}
+  other:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        toxenv: ["docs", "tz", "precommit"]
+    env:
+      TOXENV: ${{ matrix.toxenv }}
 
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - name: ${{ matrix.toxenv }}
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.10"
-  #     - name: Install tox
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         python -m pip install -U tox
-  #     - name: Run action
-  #       run: tox
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: ${{ matrix.toxenv }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -U tox
+      - name: Run action
+        run: tox
 
-  # darker:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #     - uses: actions/setup-python@v5
-  #     - uses: akaihola/darker@0fb2501a3f6c1b2d64976afa57885aeec0601182
-  #       # pinned due to unreleased fix: https://github.com/akaihola/darker/issues/489
-  #       with:
-  #         options: "--check --diff --color --isort"
-  #         src: "."
-  #         version: "~=1.7.1"
+  darker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+      - uses: akaihola/darker@0fb2501a3f6c1b2d64976afa57885aeec0601182
+        # pinned due to unreleased fix: https://github.com/akaihola/darker/issues/489
+        with:
+          options: "--check --diff --color --isort"
+          src: "."
+          version: "~=1.7.1"
 
-  # build-dist:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.10"
-  #     - name: Install tox
-  #       run: python -m pip install -U tox
-  #     - name: Run tox
-  #       run: python -m tox -e build
-  #     - name: Check generation
-  #       run: |
-  #         exactly_one() {
-  #           value=$(find dist -iname $1 | wc -l)
-  #           if [ $value -ne 1 ]; then
-  #             echo "Found $value instances of $1, not 1"
-  #             return 1
-  #           else
-  #             echo "Found exactly 1 instance of $value"
-  #           fi
-  #         }
-  #         # Check that exactly one tarball and one wheel are created
-  #         exactly_one '*.tar.gz'
-  #         exactly_one '*.whl'
+  build-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install tox
+        run: python -m pip install -U tox
+      - name: Run tox
+        run: python -m tox -e build
+      - name: Check generation
+        run: |
+          exactly_one() {
+            value=$(find dist -iname $1 | wc -l)
+            if [ $value -ne 1 ]; then
+              echo "Found $value instances of $1, not 1"
+              return 1
+            else
+              echo "Found exactly 1 instance of $value"
+            fi
+          }
+          # Check that exactly one tarball and one wheel are created
+          exactly_one '*.tar.gz'
+          exactly_one '*.whl'


### PR DESCRIPTION
Exclude python 3.7 from ubuntu-latest in validation CI since ubuntu-latest (now 24.04) no longer includes python 3.7. Pin python 3.7 validation to run on ubuntu-22.04 instead.

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
